### PR TITLE
Add mcfgthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.30)
+include(FindPkgConfig)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -7,7 +8,7 @@ project (MutexShootout)
 find_package(Boost REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 link_directories(${BOOST_LIBRARYDIR})
-	
+
 if (UNIX)
 	find_package(Threads)
 	find_package(Boost COMPONENTS system REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ include(FindPkgConfig)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
 project (MutexShootout)
 
 find_package(Boost REQUIRED)
@@ -19,5 +23,4 @@ add_executable(MutexShootout main.cpp MurmurHash3.cpp lru_cache.hpp MurmurHash3.
 if(UNIX)
 	target_link_libraries(MutexShootout ${Boost_SYSTEM_LIBRARY})
 	target_link_libraries(MutexShootout ${CMAKE_THREAD_LIBS_INIT})
-	set(CMAKE_BUILD_TYPE Release)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,18 @@ if (UNIX)
 	find_package(Boost COMPONENTS system REQUIRED)
 endif()
 
+if (WIN32)
+	pkg_check_modules(mcfgthread mcfgthread)
+endif()
+
 add_executable(MutexShootout main.cpp MurmurHash3.cpp lru_cache.hpp MurmurHash3.h hashing.hpp alt_mutex.hpp stopwatch.hpp)
 
 if(UNIX)
 	target_link_libraries(MutexShootout ${Boost_SYSTEM_LIBRARY})
 	target_link_libraries(MutexShootout ${CMAKE_THREAD_LIBS_INIT})
+endif()
+
+if (mcfgthread_FOUND)
+	target_link_libraries(MutexShootout ${mcfgthread_LINK_LIBRARIES})
+	target_compile_definitions(MutexShootout PUBLIC HAS_MCFGTHREAD)
 endif()

--- a/alt_mutex.hpp
+++ b/alt_mutex.hpp
@@ -76,3 +76,71 @@ private:
 }
 
 #endif // _WIN32
+
+#ifdef HAS_MCFGTHREAD
+
+#include <mcfgthread/mutex.h>
+
+namespace shootout {
+
+class mcf_mutex
+{
+public:
+    constexpr mcf_mutex()
+        : mtx_()
+    {
+    }
+
+    ~mcf_mutex()
+    {
+    }
+
+    mcf_mutex(const mcf_mutex&) = delete;
+    mcf_mutex& operator=(const mcf_mutex&) = delete;
+
+    void lock()
+    {
+        ::_MCF_mutex_lock(&mtx_, nullptr);  // infinite timeout
+    }
+
+    void unlock()
+    {
+        ::_MCF_mutex_unlock(&mtx_);
+    }
+
+private:
+    ::_MCF_mutex mtx_;
+};
+
+class mcf_mutex_noinline
+{
+public:
+    constexpr mcf_mutex_noinline()
+        : mtx_()
+    {
+    }
+
+    ~mcf_mutex_noinline()
+    {
+    }
+
+    mcf_mutex_noinline(const mcf_mutex_noinline&) = delete;
+    mcf_mutex_noinline& operator=(const mcf_mutex_noinline&) = delete;
+
+    void lock()
+    {
+        ::_MCF_mutex_lock_slow(&mtx_, nullptr);  // infinite timeout
+    }
+
+    void unlock()
+    {
+        ::_MCF_mutex_unlock_slow(&mtx_);
+    }
+
+private:
+    ::_MCF_mutex mtx_;
+};
+
+} // namespace shootout
+
+#endif // HAS_MCFGTHREAD

--- a/alt_mutex.hpp
+++ b/alt_mutex.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#if _WIN32
+#ifdef _WIN32
 
 #include <Windows.h>
 

--- a/main.cpp
+++ b/main.cpp
@@ -46,6 +46,9 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
         std::cerr << "|cs0|cs4k|srw";
 #endif
+#ifdef HAS_MCFGTHREAD
+        std::cerr << "|mcf|mcf0i";
+#endif
         std::cerr << '\n';
         return 1;
     }
@@ -91,6 +94,18 @@ int main(int argc, char *argv[])
     {
         elapsed_secs = run_benchmark<shootout::srw_mutex>(keys, thread_count, OP_COUNT, LRU_SIZE);
         std::cout << "srw_mutex:        " << elapsed_secs << std::endl;
+    }
+#endif
+#ifdef HAS_MCFGTHREAD
+    else if (mutex_arg == "mcf")
+    {
+        elapsed_secs = run_benchmark<shootout::mcf_mutex>(keys, thread_count, OP_COUNT, LRU_SIZE);
+        std::cout << "mcf_mutex:        " << elapsed_secs << std::endl;
+    }
+    else if (mutex_arg == "mcf0i")
+    {
+        elapsed_secs = run_benchmark<shootout::mcf_mutex_noinline>(keys, thread_count, OP_COUNT, LRU_SIZE);
+        std::cout << "mcf_mutex (noinline): " << elapsed_secs << std::endl;
     }
 #endif
     else if (mutex_arg == "nolocks")

--- a/main.cpp
+++ b/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
 {
     if (argc != 3)
     {
-#if _WIN32
+#ifdef _WIN32
         std::cerr << "Usage: " << argv[0] << " threadCount nolocks|std|boost|cs0|cs4k|srw\n";
 #else
         std::cerr << "Usage: " << argv[0] << " threadCount nolocks|std|boost\n";
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
         elapsed_secs = run_benchmark<boost::mutex>(keys, thread_count, OP_COUNT, LRU_SIZE);
         std::cout << "boost::mutex:     " << elapsed_secs << std::endl;
     }
-#if _WIN32
+#ifdef _WIN32
     else if (mutex_arg == "cs0")
     {
         elapsed_secs = run_benchmark<shootout::cs_mutex<0>>(keys, thread_count, OP_COUNT, LRU_SIZE);

--- a/main.cpp
+++ b/main.cpp
@@ -42,11 +42,11 @@ int main(int argc, char *argv[])
 {
     if (argc != 3)
     {
+        std::cerr << "Usage: " << argv[0] << " threadCount nolocks|std|boost";
 #ifdef _WIN32
-        std::cerr << "Usage: " << argv[0] << " threadCount nolocks|std|boost|cs0|cs4k|srw\n";
-#else
-        std::cerr << "Usage: " << argv[0] << " threadCount nolocks|std|boost\n";
+        std::cerr << "|cs0|cs4k|srw";
 #endif
+        std::cerr << '\n';
         return 1;
     }
     char *end;


### PR DESCRIPTION
The mcfgthread library <https://github.com/lhmouse/mcfgthread> implements fast mutex and condition variables on Windows. To test mcfgthread, it's necessary to set up an environment in an MSYS2 UCRT64 shell:

```text
  # pacman -S mingw-w64-ucrt-x86_64-{cmake,pkgconf,ninja,boost,mcfgthread}
  # cmake .
  # ninja
  # ./MutexShootout.exe
  Usage: D:\lh_mouse\GitHub\MutexShootout\MutexShootout.exe threadCount nolocks|std|boost|cs0|cs4k|srw|mcf|mcf0i
```
`mcf` allows the locking and unlocking functions to be inlined, while `mcf0i` calls external functions.

Results:

```text
  $ ./MutexShootout.exe 16 srw
  srw_mutex:        29.3014
  $ ./MutexShootout.exe 16 mcf
  mcf_mutex:        14.2265
  $ ./MutexShootout.exe 16 mcf0i
  mcf_mutex (noinline): 13.4116
```
